### PR TITLE
Upgrades to AB 2.35.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+
+## v1.1.0 - 2021-06-25
+
+### Added
+
+* [PIPELINE-735](https://globalfishingwatch.atlassian.net/browse/PIPELINE-735):
+  Upgrade to `Apache Beam:2.35.0` and pins package versions to avoid pip
+  download unnecesary packages for backtracking.
+
+## v1.0.0 - 2021-06-25
+
+### Added
+
+* [PIPELINE-377](https://globalfishingwatch.atlassian.net/browse/PIPELINE-377):
+  Deploy loitering for core pipeline.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,4 +38,4 @@ steps:
   ]
   waitFor: [ 'build', 'test' ]
 
-timeout: 900s
+timeout: 600s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,4 +38,4 @@ steps:
   ]
   waitFor: [ 'build', 'test' ]
 
-timeout: 600s
+timeout: 900s

--- a/loitering/merge_raw_loitering/__init__.py
+++ b/loitering/merge_raw_loitering/__init__.py
@@ -35,7 +35,6 @@ def run_merge_raw_loitering(argv):
     job = bq_client.query(query, bigquery.QueryJobConfig(
         write_disposition=bigquery.job.WriteDisposition.WRITE_TRUNCATE,
         destination=options.destination,
-        destination_table_description="Consolidated loitering events",
         clustering_fields=['ssvid'],
         time_partitioning=bigquery.table.TimePartitioning(
             type_=bigquery.table.TimePartitioningType.DAY,

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,6 +1,6 @@
 # Apache beam
-apache-beam==2.28.0
-apache-beam[gcp]==2.28.0
+apache-beam==2.35.0
+apache-beam[gcp]==2.35.0
 
 # Other infrastructure we need locally on the local environment
 jinja2

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -3,8 +3,16 @@ apache-beam==2.35.0
 apache-beam[gcp]==2.35.0
 
 # Other infrastructure we need locally on the local environment
-jinja2
-google-cloud-bigquery
+jinja2==3.0.3
+google-cloud-bigquery==2.32.0
+
+#Pin versions due to Pip downloads by backtracking
+google_auth==1.35.0
+fasteners==0.17.3
+google_cloud_bigtable==1.7.0
+google_cloud_bigquery_storage==2.11.0
+google_api_core==1.31.5
 
 # Testing
-pytest
+pytest==6.2.5
+pyparsing==2.4.7

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='loitering',
-    version='1.0.0',
+    version='1.1.0',
     packages=find_packages(exclude=['test*.*', 'tests']),
     install_requires=[],
 )


### PR DESCRIPTION
- upgrades to AB 2.35.0
- made test under scratch_matias_ttl_60_days.
- Compare results in https://datastudio.google.com/reporting/4f9d27bf-2c54-41bf-adfd-546f6703bfb1
- removes property destination_table_description that was removed from QueryJobConfig (newer versions)

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-735