### PR TITLE
Pipe-v3: Adds support for AB-2.49

### DIFF
--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.8_sdk:2.40.0
+FROM apache/beam_python3.8_sdk:2.49.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,4 +1,4 @@
-apache-beam[gcp]==2.40.0
+apache-beam[gcp]==2.49.0
 jinja2==3.0.3
-pytest==6.2.5
+pytest==7.2.2
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='loitering',
-    version='4.0.0',
+    version='4.1.0',
     packages=find_packages(exclude=['test*.*', 'tests']),
 )
 


### PR DESCRIPTION
This is for pipe-v3:
- Increments the Apache Beam version from [2.40](https://github.com/apache/beam/releases/tag/v2.40.0) to [2.49](https://github.com/apache/beam/releases/tag/v2.49.0)

Tests were running ok. There was an increment of warnings.

Also run the loitering steps, the results were set in the `scratch_matias_ttl_60_days`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1423