### PR TITLE
Filters out the messages that only has one message per seg_id

### DIFF
--- a/loitering/create_raw_loitering/transforms/calculate_loitering_stats.py
+++ b/loitering/create_raw_loitering/transforms/calculate_loitering_stats.py
@@ -41,12 +41,20 @@ def convert_to_loitering_daily_event(msgs):
         "end_lat": msgs[-1]["lat"],
     }
 
+def has_more_than_one_messages(msgs):
+    return len(msgs) > 1
+
 class CalculateLoiteringStats(beam.PTransform):
     def expand(self, pcoll):
         return (
             pcoll
+            | self.filter_out_only_one_message_segs()
             | self.convert_to_loitering_daily_event()
         )
 
+    def filter_out_only_one_message_segs(self):
+        return beam.Filter(has_more_than_one_messages)
+
     def convert_to_loitering_daily_event(self):
         return beam.Map(convert_to_loitering_daily_event)
+

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='loitering',
-    version='4.1.0',
+    version='4.1.1',
     packages=find_packages(exclude=['test*.*', 'tests']),
 )
 

--- a/tests/create_raw_loitering/transforms/test_calculate_loitering_stats.py
+++ b/tests/create_raw_loitering/transforms/test_calculate_loitering_stats.py
@@ -1,5 +1,6 @@
 import loitering.create_raw_loitering.transforms.calculate_loitering_stats as stats
 import pytest
+import datetime as dt
 
 class TestCalculateAvgSpeedInKnots:
     def test_calculate_avg_speed_in_knots_zero_hours(self):
@@ -94,3 +95,58 @@ class TestCalculateAvgDistanceFromShoreNM:
         result = stats.calculate_avg_distance_from_shore_nm(msgs)
 
         assert result == 1
+
+class TestConvertToLoiteringDailyEvents:
+    def test_only_one_message(self):
+        msgs = [{
+            'ssvid': '503040990',
+            'seg_id': '503040990-2023-10-27T00:31:23.000000Z-1',
+            'timestamp': dt.datetime(2023, 10, 28, 0, 14, 54, tzinfo=dt.timezone.utc),
+            'meters_to_prev': 20167.090529863097,
+            'hours': 23.725277777777777,
+            'lat': -20.174032,
+            'lon': 148.89871,
+            'distance_from_shore_m': 1000.0
+        }]
+        result = stats.has_more_than_one_messages(msgs)
+
+        assert result == False
+
+    def test_convert_to_loitering_daily_events(self):
+        msgs = [{
+            'ssvid': '503040990',
+            'seg_id': '503040990-2023-10-27T00:31:23.000000Z-1',
+            'timestamp': dt.datetime(2023, 10, 28, 0, 14, 54, tzinfo=dt.timezone.utc),
+            'meters_to_prev': 20167.090529863097,
+            'hours': 23.725277777777777,
+            'lat': -20.174032,
+            'lon': 148.89871,
+            'distance_from_shore_m': 1000.0
+        },{
+            'ssvid': '503040990',
+            'seg_id': '503040990-2023-10-27T01:31:23.000000Z-1',
+            'timestamp': dt.datetime(2023, 10, 28, 1, 14, 54, tzinfo=dt.timezone.utc),
+            'meters_to_prev': 20267.090529863097,
+            'hours': 23.725277777777777,
+            'lat': -20.174042,
+            'lon': 148.89871,
+            'distance_from_shore_m': 1003.0
+        }]
+
+        result = stats.convert_to_loitering_daily_event(msgs)
+
+        assert result == {
+            'avg_distance_from_shore_nm': 0.5407667386609072,
+            'avg_speed_knots': 0.4612529100967032,
+            'end_lat': -20.174042,
+            'end_lon': 148.89871,
+            'loitering_end_timestamp': dt.datetime(2023, 10, 28, 1, 14, 54, tzinfo=dt.timezone.utc),
+            'loitering_hours': 23.725277777777777,
+            'loitering_start_timestamp': dt.datetime(2023, 10, 28, 0, 14, 54, tzinfo=dt.timezone.utc),
+            'seg_id': '503040990-2023-10-27T00:31:23.000000Z-1',
+            'ssvid': '503040990',
+            'start_lat': -20.174032,
+            'start_lon': 148.89871,
+            'tot_distance_nm': 10.943353417852643
+        }
+


### PR DESCRIPTION
- Adds a step in the pipeline to filter out the messages that has only one message per seg_id. Conceptually having only one message in the list of seg_id is not useful for doing the calculations of the loitering.
- Adds test for the functions that were implicated.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1551